### PR TITLE
Fix: Python module import errors in tests

### DIFF
--- a/crawl4ai_mcp/event_store.py
+++ b/crawl4ai_mcp/event_store.py
@@ -135,3 +135,7 @@ class SimpleEventStore:
     ) -> Optional[str]:
         """No events to replay in simple mode."""
         return None
+
+
+# Default export - use CorrectEventStore as the default EventStore
+EventStore = CorrectEventStore

--- a/crawl4ai_mcp/handles/base.py
+++ b/crawl4ai_mcp/handles/base.py
@@ -5,7 +5,7 @@ import logging
 from typing import Dict, Any, Sequence, List
 from mcp import Tool
 from mcp.types import TextContent
-from config.settings import settings
+from crawl4ai_mcp.config.settings import settings
 
 logger = logging.getLogger(__name__)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,7 +95,7 @@ Issues = "https://github.com/stgmt/crawl4ai-mcp/issues"
 crawl4ai-mcp = "crawl4ai_mcp.__main__:main"
 
 [tool.setuptools]
-packages = ["crawl4ai_mcp"]
+packages = {find = {where = ["."], include = ["crawl4ai_mcp*"]}}
 
 [tool.setuptools.package-data]
 crawl4ai_mcp = ["py.typed"]


### PR DESCRIPTION
## Исправление проблемы

Исправлена ошибка `ModuleNotFoundError: No module named 'crawl4ai_mcp_sse_stdio'` которая возникала при запуске Python тестов в GitHub Actions.

## Изменения

### 1. pyproject.toml
- Исправлена конфигурация setuptools для правильного обнаружения пакета
- Изменено с `packages = ["crawl4ai_mcp"]` на `packages = {find = {where = ["."], include = ["crawl4ai_mcp*"]}}`
- Это позволяет правильно устанавливать пакет даже когда имя в PyPI отличается от имени папки

### 2. crawl4ai_mcp/event_store.py
- Добавлен экспорт `EventStore = CorrectEventStore` в конец файла
- Исправляет ошибку импорта `EventStore` в server.py

### 3. crawl4ai_mcp/handles/base.py
- Исправлен относительный импорт
- Изменено с `from config.settings import settings` на `from crawl4ai_mcp.config.settings import settings`

## Тестирование

Проверено локально:
- ✅ Импорт модуля работает: `from crawl4ai_mcp.server import Crawl4AIMCPServer`
- ✅ Пакет устанавливается через `pip install -e .`
- ✅ Все импорты резолвятся корректно

## Проблема решена

Эти изменения исправляют проблему с падающими тестами Python в CI/CD pipeline.